### PR TITLE
fix: lock numpy to v1.26.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ pyyaml
 drmaa==0.7.9  # if using drmaa scheduler
 smart_open<7.0.0
 git+https://github.com/elleira/bamsnap.git@f4bc661c4e53a6ca21537c98c4f79080d19275bf
+numpy==1.26.4


### PR DESCRIPTION
Got error for cnvkit_call if numpy v2.0.2

### This PR:

(If this is a release PR, no need to add following. Leave this part empty)
(Use the following lines to create a PR text body. Make sure to remove all non-relevant one after you're done)
(Repeat each field as many times as necessary)

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
