### PR TITLE
Make output for multiqc comply with current ductus-packs

### DIFF
--- a/config/output_files.yaml
+++ b/config/output_files.yaml
@@ -10,7 +10,7 @@ files:
 
   - name: MultiQC
     input: qc/multiqc/multiqc_DNA.html
-    output: "{sequenceid}_MultiQC_DNA.html"
+    output: "multiqc_{sequenceid}.html"
 
   - name: SNVs and indels VCF file
     input: "snv_indels/bcftools_concat/{sample}_{type}.filter.somatic.vcf.gz"


### PR DESCRIPTION
MultiQC report should be copied to Results and QC folders in AL_SEQ (retrieve_results_wp task).

### This PR:

(If this is a release PR, no need to add following. Leave this part empty)
(Use the following lines to create a PR text body. Make sure to remove all non-relevant one after you're done)
(Repeat each field as many times as necessary)

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests: 
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
